### PR TITLE
Add React Native project base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Subastas
+
+Este repositorio contiene un ejemplo básico de una aplicación React Native en el directorio `react-native-app`.
+
+## Contenido
+
+- `react-native-app/`: proyecto base de React Native

--- a/react-native-app/App.js
+++ b/react-native-app/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Welcome to React Native!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/react-native-app/README.md
+++ b/react-native-app/README.md
@@ -1,0 +1,3 @@
+# React Native App
+
+This directory contains a minimal React Native project setup. You can start the Metro bundler with `npm start` and run the application on Android or iOS devices using `npm run android` or `npm run ios`.

--- a/react-native-app/app.json
+++ b/react-native-app/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "ReactNativeApp",
+  "displayName": "ReactNativeApp"
+}

--- a/react-native-app/babel.config.js
+++ b/react-native-app/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/react-native-app/index.js
+++ b/react-native-app/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/react-native-app/package.json
+++ b/react-native-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ReactNativeApp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize a minimal React Native project in `react-native-app`
- update root README with project info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd6eb67f0832a8cb881642933e705